### PR TITLE
Fix iOS code signing workflow and move logic to JavaScript

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -9,39 +9,29 @@ on:
 
   workflow_dispatch:
 
-env:
-  DEVELOPER_DIR: /Applications/Xcode_15.0.app/Contents/Developer
-
 jobs:
   testflight:
-    runs-on: macos-13
-    
+    runs-on: macos-latest
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-      
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
         node-version: '18'
         cache: 'npm'
-        
     - name: Install dependencies
       run: npm ci
-      
     - name: Build extension assets
       run: npm run build
-      
     - name: Setup Xcode
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '15.0'
+        xcode-version: 'latest-stable'
     - name: Make scripts executable
       run: chmod +x scripts/*.js
-      
     - name: Install jq
       run: brew install jq
-      
     - name: Build iOS app (and upload to TestFlight if on main branch or tag)
       env:
         BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,0 +1,61 @@
+name: Deploy to TestFlight
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+env:
+  DEVELOPER_DIR: /Applications/Xcode_15.0.app/Contents/Developer
+
+jobs:
+  testflight:
+    runs-on: macos-13
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18'
+        cache: 'npm'
+        
+    - name: Install dependencies
+      run: npm ci
+      
+    - name: Build extension assets
+      run: npm run build
+      
+    - name: Setup Xcode
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '15.0'
+        
+    - name: Make scripts executable
+      run: chmod +x scripts/*.js
+      
+    - name: Install jq
+      run: brew install jq
+      
+    - name: Build iOS app (and upload to TestFlight if on main branch or tag)
+      env:
+        BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+        P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+        APP_PROVISIONING_PROFILE_BASE64: ${{ secrets.APP_PROVISIONING_PROFILE_BASE64 }}
+        EXTENSION_PROVISIONING_PROFILE_BASE64: ${{ secrets.EXTENSION_PROVISIONING_PROFILE_BASE64 }}
+        APPLE_ID: ${{ secrets.APPLE_ID }}
+        APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
+        RUNNER_TEMP: ${{ runner.temp }}
+      run: |
+        if [[ "${{ github.event_name }}" == "push" && ("${{ github.ref }}" == "refs/heads/main" || "${{ github.ref }}" == "refs/tags/"*) ]]; then
+          echo "Running full build and TestFlight upload..."
+          npm run ios-build-testflight
+        else
+          echo "Running build only (no TestFlight upload) for pull request..."
+          npm run ios-build-local
+        fi

--- a/bar123 Extension/Resources/popup.js
+++ b/bar123 Extension/Resources/popup.js
@@ -1,6 +1,4 @@
-<<<<<<< HEAD
-console.log("Hello World!", browser);
-=======
+
 class HistorySyncUI {
     constructor() {
         this.initializeElements();
@@ -231,4 +229,3 @@ browser.runtime.onMessage.addListener((message) => {
 document.addEventListener('DOMContentLoaded', () => {
     window.historySyncUI = new HistorySyncUI();
 });
->>>>>>> 6a3c53c (Initial Commit)

--- a/bar123.xcodeproj/project.pbxproj
+++ b/bar123.xcodeproj/project.pbxproj
@@ -386,9 +386,11 @@
 		CE03C4482DDF94E1008CC9F2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 2858MX5336;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2858MX5336;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "bar123 Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "bar123 Extension";
@@ -406,6 +408,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.foo.bar123.Extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = xyz.foo.bar123.Extension;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -416,9 +420,11 @@
 		CE03C4492DDF94E1008CC9F2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 2858MX5336;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2858MX5336;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "bar123 Extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "bar123 Extension";
@@ -436,6 +442,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.foo.bar123.Extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = xyz.foo.bar123.Extension;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -448,9 +456,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 2858MX5336;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2858MX5336;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = bar123/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = bar123;
@@ -473,6 +483,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.foo.bar123;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "bar123 App Store";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -484,9 +496,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 2858MX5336;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 2858MX5336;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = bar123/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = bar123;
@@ -509,6 +523,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.foo.bar123;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "bar123 App Store";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/bar123.xcodeproj/project.pbxproj
+++ b/bar123.xcodeproj/project.pbxproj
@@ -386,6 +386,7 @@
 		CE03C4482DDF94E1008CC9F2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
@@ -409,7 +410,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.foo.bar123.Extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = xyz.foo.bar123.Extension;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = bar123Ext;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -420,6 +421,7 @@
 		CE03C4492DDF94E1008CC9F2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
@@ -443,7 +445,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.foo.bar123.Extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = xyz.foo.bar123.Extension;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = bar123Ext;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -456,6 +458,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
@@ -484,7 +487,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.foo.bar123;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "bar123 App Store";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = bar123App;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -496,6 +499,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
@@ -524,7 +528,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = xyz.foo.bar123;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "bar123 App Store";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = bar123App;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/docs/ios-code-signing.md
+++ b/docs/ios-code-signing.md
@@ -1,0 +1,103 @@
+# iOS Code Signing Guide
+
+This document explains how to generate and set up the required secrets for iOS code signing in the GitHub Actions workflow.
+
+## Required Secrets
+
+The following secrets need to be set in your GitHub repository:
+
+1. `BUILD_CERTIFICATE_BASE64`: Base64-encoded p12 certificate
+2. `P12_PASSWORD`: Password for the p12 certificate
+3. `APP_PROVISIONING_PROFILE_BASE64`: Base64-encoded app provisioning profile
+4. `EXTENSION_PROVISIONING_PROFILE_BASE64`: Base64-encoded extension provisioning profile
+5. `APPLE_ID`: Apple ID email
+6. `APP_SPECIFIC_PASSWORD`: App-specific password for Apple ID
+
+## Generating the Secrets
+
+### Certificate (P12)
+
+1. Open Keychain Access on your Mac
+2. Select the certificate you want to export (should include the private key)
+3. Right-click and select "Export"
+4. Choose the .p12 format and set a strong password
+5. Convert to base64:
+   ```bash
+   base64 -i certificate.p12 | pbcopy
+   ```
+
+### Provisioning Profiles
+
+1. Download the provisioning profiles from the Apple Developer Portal
+   - One for the main app
+   - One for the extension
+2. Convert to base64:
+   ```bash
+   base64 -i profile.mobileprovision | pbcopy
+   ```
+
+### App-Specific Password
+
+1. Go to https://appleid.apple.com/
+2. Sign in with your Apple ID
+3. Go to "Security" > "App-Specific Passwords"
+4. Click "Generate Password" and follow the instructions
+
+## Setting the Secrets in GitHub
+
+1. Go to your GitHub repository
+2. Click on "Settings" > "Secrets and variables" > "Actions"
+3. Click "New repository secret"
+4. Add each of the required secrets with their respective values
+
+## Troubleshooting
+
+### MAC Verification Failed
+
+If you see an error like:
+```
+security: SecKeychainItemImport: MAC verification failed during PKCS12 import (wrong password?)
+```
+
+This means either:
+1. The P12 password is incorrect
+2. The P12 certificate is corrupted or improperly encoded
+
+To fix:
+1. Re-export the certificate from Keychain Access
+2. Make sure to use the correct password
+3. Ensure the base64 encoding is done properly without line breaks:
+   ```bash
+   base64 -i certificate.p12 | tr -d '\n' | pbcopy
+   ```
+
+### Provisioning Profile Issues
+
+If you encounter provisioning profile errors:
+1. Make sure the profiles are still valid and not expired
+2. Verify the profiles are for the correct app bundle identifiers
+3. Check that the profiles are properly encoded in base64
+4. Ensure the team ID in the workflow matches the team ID in the profiles
+
+## Manual Testing
+
+You can test the code signing process locally using the npm scripts:
+
+```bash
+# Install dependencies
+npm install
+
+# Set environment variables
+export BUILD_CERTIFICATE_BASE64="your_base64_certificate"
+export P12_PASSWORD="your_p12_password"
+export APP_PROVISIONING_PROFILE_BASE64="your_base64_app_profile"
+export EXTENSION_PROVISIONING_PROFILE_BASE64="your_base64_extension_profile"
+
+# Build locally without uploading to TestFlight
+npm run ios-build-local
+
+# Build and upload to TestFlight
+export APPLE_ID="your_apple_id@example.com"
+export APP_SPECIFIC_PASSWORD="your_app_specific_password"
+npm run ios-build-testflight
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,9 @@
       "dependencies": {
         "peerjs": "^1.4.7"
       },
-      "devDependencies": {}
+      "devDependencies": {
+        "commander": "^11.1.0"
+      }
     },
     "node_modules/@msgpack/msgpack": {
       "version": "2.8.0",
@@ -20,6 +22,16 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/eventemitter3": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,12 @@
     "test-ui": "npm run build && xcodebuild test -project bar123.xcodeproj -scheme bar123UITests -destination 'platform=iOS Simulator,name=iPhone 15'",
     "test-full": "npm run test-integration && npm run test",
     "test-real": "node real-simulator-test.js",
-    "test-verify": "node real-simulator-test.js --verify-only"
+    "test-verify": "node real-simulator-test.js --verify-only",
+    
+    "prepare-profiles": "node scripts/prepare-profiles.js",
+    "ios-build": "node scripts/ios-build.js --certificate $RUNNER_TEMP/ios-profiles/certificate.p12 --password $P12_PASSWORD --app-profile $RUNNER_TEMP/ios-profiles/app_profile.mobileprovision --ext-profile $RUNNER_TEMP/ios-profiles/extension_profile.mobileprovision --output $RUNNER_TEMP/build",
+    "ios-build-testflight": "npm run prepare-profiles && npm run ios-build -- --upload --apple-id $APPLE_ID --app-password $APP_SPECIFIC_PASSWORD",
+    "ios-build-local": "npm run prepare-profiles && npm run ios-build"
   },
   "keywords": [
     "safari",
@@ -32,7 +37,9 @@
   "dependencies": {
     "peerjs": "^1.4.7"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "commander": "^11.1.0"
+  },
   "author": "History Sync Extension",
   "license": "MIT"
 }

--- a/scripts/ios-build.js
+++ b/scripts/ios-build.js
@@ -1,0 +1,254 @@
+#!/usr/bin/env node
+
+/**
+ * iOS Build Script
+ * 
+ * This script handles the iOS build process including:
+ * - Setting up code signing
+ * - Building the Xcode project
+ * - Creating an IPA file
+ * - Uploading to TestFlight (if requested)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process');
+const { program } = require('commander');
+
+// Configure command line options
+program
+  .option('-c, --certificate <path>', 'Path to p12 certificate file')
+  .option('-p, --password <password>', 'Certificate password')
+  .option('-a, --app-profile <path>', 'Path to app provisioning profile')
+  .option('-e, --ext-profile <path>', 'Path to extension provisioning profile')
+  .option('-o, --output <path>', 'Output directory for IPA file', process.env.RUNNER_TEMP || './build')
+  .option('-u, --upload', 'Upload to TestFlight after building')
+  .option('-i, --apple-id <email>', 'Apple ID for TestFlight upload')
+  .option('-s, --app-password <password>', 'App-specific password for TestFlight upload')
+  .parse(process.argv);
+
+const options = program.opts();
+
+// Validate required options
+if (!options.certificate || !options.password || !options.appProfile || !options.extProfile) {
+  console.error('Error: Missing required options. Use --help for more information.');
+  process.exit(1);
+}
+
+// Create output directory if it doesn't exist
+if (!fs.existsSync(options.output)) {
+  fs.mkdirSync(options.output, { recursive: true });
+}
+
+// Setup keychain and import certificate
+function setupCodeSigning() {
+  console.log('Setting up code signing...');
+  
+  try {
+    // Create temporary keychain
+    execSync(`security create-keychain -p "temp-password" signing_temp.keychain`);
+    execSync(`security set-keychain-settings -lut 21600 signing_temp.keychain`);
+    execSync(`security unlock-keychain -p "temp-password" signing_temp.keychain`);
+    
+    // Import certificate
+    execSync(`security import "${options.certificate}" -k signing_temp.keychain -f pkcs12 -A -T /usr/bin/codesign -T /usr/bin/security -P "${options.password}"`);
+    
+    // Set keychain search list
+    execSync(`security list-keychains -d user -s signing_temp.keychain $(security list-keychains -d user | sed s/\\"//g)`);
+    execSync(`security default-keychain -s signing_temp.keychain`);
+    execSync(`security set-key-partition-list -S apple-tool:,apple: -s -k "temp-password" signing_temp.keychain`);
+    
+    // Install provisioning profiles
+    const profilesDir = path.join(process.env.HOME, 'Library/MobileDevice/Provisioning Profiles');
+    if (!fs.existsSync(profilesDir)) {
+      fs.mkdirSync(profilesDir, { recursive: true });
+    }
+    
+    fs.copyFileSync(options.appProfile, path.join(profilesDir, 'app_profile.mobileprovision'));
+    fs.copyFileSync(options.extProfile, path.join(profilesDir, 'extension_profile.mobileprovision'));
+    
+    console.log('Code signing setup complete.');
+  } catch (error) {
+    console.error('Error setting up code signing:', error.message);
+    process.exit(1);
+  }
+}
+
+// Extract provisioning profile UUIDs
+function getProfileUUIDs() {
+  console.log('Extracting provisioning profile UUIDs...');
+  
+  const profilesDir = path.join(process.env.HOME, 'Library/MobileDevice/Provisioning Profiles');
+  const appProfilePath = path.join(profilesDir, 'app_profile.mobileprovision');
+  const extProfilePath = path.join(profilesDir, 'extension_profile.mobileprovision');
+  
+  try {
+    // Extract UUIDs using grep
+    const appProfileUUID = execSync(`grep -a -A 1 UUID "${appProfilePath}" | grep -o "[-A-Za-z0-9]\\{36\\}"`).toString().trim();
+    const extProfileUUID = execSync(`grep -a -A 1 UUID "${extProfilePath}" | grep -o "[-A-Za-z0-9]\\{36\\}"`).toString().trim();
+    
+    console.log(`App Profile UUID: ${appProfileUUID}`);
+    console.log(`Extension Profile UUID: ${extProfileUUID}`);
+    
+    return { appProfileUUID, extProfileUUID };
+  } catch (error) {
+    console.error('Error extracting profile UUIDs:', error.message);
+    process.exit(1);
+  }
+}
+
+// Build Xcode project
+function buildArchive(uuids) {
+  console.log('Building Xcode archive...');
+  
+  const archivePath = path.join(options.output, 'bar123.xcarchive');
+  
+  try {
+    execSync(`xcodebuild \
+      -project bar123.xcodeproj \
+      -scheme bar123 \
+      -destination generic/platform=iOS \
+      -archivePath "${archivePath}" \
+      archive \
+      CODE_SIGN_STYLE=Manual \
+      CODE_SIGN_IDENTITY="iPhone Distribution" \
+      PROVISIONING_PROFILE="${uuids.appProfileUUID}" \
+      "PROVISIONING_PROFILE[sdk=iphoneos*]"="${uuids.appProfileUUID}" \
+      PROVISIONING_PROFILE_xyz_foo_bar123_Extension="${uuids.extProfileUUID}"`, 
+      { stdio: 'inherit' });
+    
+    console.log('Archive build complete.');
+    return archivePath;
+  } catch (error) {
+    console.error('Error building archive:', error.message);
+    process.exit(1);
+  }
+}
+
+// Create export options plist
+function createExportOptions(uuids) {
+  console.log('Creating export options plist...');
+  
+  const exportOptionsPath = path.join(options.output, 'ExportOptions.plist');
+  const exportOptionsContent = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>destination</key>
+  <string>upload</string>
+  <key>method</key>
+  <string>app-store</string>
+  <key>teamID</key>
+  <string>2858MX5336</string>
+  <key>signingStyle</key>
+  <string>manual</string>
+  <key>provisioningProfiles</key>
+  <dict>
+    <key>xyz.foo.bar123</key>
+    <string>${uuids.appProfileUUID}</string>
+    <key>xyz.foo.bar123.Extension</key>
+    <string>${uuids.extProfileUUID}</string>
+  </dict>
+  <key>uploadBitcode</key>
+  <false/>
+  <key>uploadSymbols</key>
+  <true/>
+  <key>compileBitcode</key>
+  <false/>
+</dict>
+</plist>`;
+  
+  fs.writeFileSync(exportOptionsPath, exportOptionsContent);
+  console.log('Export options created at:', exportOptionsPath);
+  
+  return exportOptionsPath;
+}
+
+// Export IPA
+function exportIPA(archivePath, exportOptionsPath) {
+  console.log('Exporting IPA...');
+  
+  try {
+    execSync(`xcodebuild \
+      -exportArchive \
+      -archivePath "${archivePath}" \
+      -exportOptionsPlist "${exportOptionsPath}" \
+      -exportPath "${options.output}"`, 
+      { stdio: 'inherit' });
+    
+    const ipaPath = path.join(options.output, 'bar123.ipa');
+    console.log('IPA export complete:', ipaPath);
+    
+    return ipaPath;
+  } catch (error) {
+    console.error('Error exporting IPA:', error.message);
+    process.exit(1);
+  }
+}
+
+// Upload to TestFlight
+function uploadToTestFlight(ipaPath) {
+  if (!options.upload) {
+    console.log('Skipping TestFlight upload (use --upload to enable)');
+    return;
+  }
+  
+  if (!options.appleId || !options.appPassword) {
+    console.error('Error: Apple ID and app-specific password required for TestFlight upload');
+    process.exit(1);
+  }
+  
+  console.log('Uploading to TestFlight...');
+  
+  try {
+    execSync(`xcrun altool --upload-app -f "${ipaPath}" \
+      -t ios \
+      -u "${options.appleId}" \
+      -p "${options.appPassword}" \
+      --verbose`, 
+      { stdio: 'inherit' });
+    
+    console.log('TestFlight upload complete.');
+  } catch (error) {
+    console.error('Error uploading to TestFlight:', error.message);
+    process.exit(1);
+  }
+}
+
+// Cleanup
+function cleanup() {
+  console.log('Cleaning up...');
+  
+  try {
+    execSync('security default-keychain -s login.keychain');
+    execSync('security delete-keychain signing_temp.keychain');
+    console.log('Cleanup complete.');
+  } catch (error) {
+    console.warn('Warning during cleanup:', error.message);
+  }
+}
+
+// Main function
+async function main() {
+  try {
+    setupCodeSigning();
+    const uuids = getProfileUUIDs();
+    const archivePath = buildArchive(uuids);
+    const exportOptionsPath = createExportOptions(uuids);
+    const ipaPath = exportIPA(archivePath, exportOptionsPath);
+    
+    if (options.upload) {
+      uploadToTestFlight(ipaPath);
+    }
+    
+    console.log('Build process completed successfully!');
+  } catch (error) {
+    console.error('Build process failed:', error.message);
+    process.exit(1);
+  } finally {
+    cleanup();
+  }
+}
+
+// Run the main function
+main();

--- a/scripts/ios-build.js
+++ b/scripts/ios-build.js
@@ -129,15 +129,17 @@ function buildArchive(uuids) {
 function createExportOptions(uuids) {
   console.log('Creating export options plist...');
   
+  if (!uuids.appProfileUUID || !uuids.extProfileUUID) {
+    throw new Error('Profile UUIDs are required for export options');
+  }
+  
   const exportOptionsPath = path.join(options.output, 'ExportOptions.plist');
   const exportOptionsContent = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>destination</key>
-  <string>upload</string>
   <key>method</key>
-  <string>app-store</string>
+  <string>app-store-connect</string>
   <key>teamID</key>
   <string>2858MX5336</string>
   <key>signingStyle</key>

--- a/scripts/prepare-profiles.js
+++ b/scripts/prepare-profiles.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+
+/**
+ * Prepare Provisioning Profiles Script
+ * 
+ * This script decodes base64-encoded provisioning profiles and certificates
+ * and saves them to temporary files for use in the build process.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+// Create a consistent directory for the profiles
+const tempDir = process.env.RUNNER_TEMP ? path.join(process.env.RUNNER_TEMP, 'ios-profiles') : fs.mkdtempSync(path.join(os.tmpdir(), 'ios-profiles-'));
+
+// Ensure the directory exists
+if (!fs.existsSync(tempDir)) {
+  fs.mkdirSync(tempDir, { recursive: true });
+}
+
+console.log(`Using profiles directory: ${tempDir}`);
+
+// Function to decode and save a base64 string to a file
+function decodeBase64ToFile(base64String, outputPath) {
+  if (!base64String) {
+    throw new Error(`Base64 string is empty or undefined`);
+  }
+  
+  // Remove any whitespace that might be in the base64 string
+  const cleanedBase64 = base64String.replace(/\s/g, '');
+  
+  // Decode and write to file
+  const buffer = Buffer.from(cleanedBase64, 'base64');
+  fs.writeFileSync(outputPath, buffer);
+  
+  console.log(`Decoded file saved to: ${outputPath}`);
+  return outputPath;
+}
+
+// Main function
+function main() {
+  try {
+    // Get base64 encoded values from environment variables
+    const certificateBase64 = process.env.BUILD_CERTIFICATE_BASE64;
+    const appProfileBase64 = process.env.APP_PROVISIONING_PROFILE_BASE64;
+    const extProfileBase64 = process.env.EXTENSION_PROVISIONING_PROFILE_BASE64;
+    
+    // Validate environment variables
+    if (!certificateBase64) {
+      throw new Error('BUILD_CERTIFICATE_BASE64 environment variable is required');
+    }
+    if (!appProfileBase64) {
+      throw new Error('APP_PROVISIONING_PROFILE_BASE64 environment variable is required');
+    }
+    if (!extProfileBase64) {
+      throw new Error('EXTENSION_PROVISIONING_PROFILE_BASE64 environment variable is required');
+    }
+    
+    // Define output paths
+    const certificatePath = path.join(tempDir, 'certificate.p12');
+    const appProfilePath = path.join(tempDir, 'app_profile.mobileprovision');
+    const extProfilePath = path.join(tempDir, 'extension_profile.mobileprovision');
+    
+    // Decode and save files
+    decodeBase64ToFile(certificateBase64, certificatePath);
+    decodeBase64ToFile(appProfileBase64, appProfilePath);
+    decodeBase64ToFile(extProfileBase64, extProfilePath);
+    
+    // Output paths as JSON for the next step in the workflow
+    const result = {
+      certificatePath,
+      appProfilePath,
+      extProfilePath,
+      tempDir
+    };
+    
+    // Write to output file if specified
+    if (process.env.GITHUB_OUTPUT) {
+      fs.appendFileSync(process.env.GITHUB_OUTPUT, `paths=${JSON.stringify(result)}\n`);
+    }
+    
+    // Also print to stdout for local usage
+    console.log(JSON.stringify(result, null, 2));
+    
+    return result;
+  } catch (error) {
+    console.error('Error preparing profiles:', error.message);
+    process.exit(1);
+  }
+}
+
+// Run the main function
+main();


### PR DESCRIPTION
## Description
This PR fixes the iOS code signing workflow by replacing the App Store Connect API-based provisioning profile download with a more direct approach using pre-created provisioning profiles. It also moves the build logic from the GitHub Actions workflow into JavaScript scripts for better maintainability.

## Changes
- Moved iOS build logic from GitHub Actions workflow to JavaScript scripts
- Added npm scripts for building and uploading to TestFlight
- Simplified the GitHub Actions workflow to use the new npm scripts
- Removed the App Store Connect API dependency for provisioning profiles
- Enhanced export options to include provisioning profile information
- Simplified TestFlight upload to use Apple ID with app-specific password
- Added detailed documentation for iOS code signing setup
- **Added TestFlight workflow for PRs targeting main branch** (build only, no upload)

## Required Secrets
To use this updated workflow, the following GitHub secrets need to be set:
- `BUILD_CERTIFICATE_BASE64`: Base64-encoded p12 certificate
- `P12_PASSWORD`: Password for the p12 certificate
- `APP_PROVISIONING_PROFILE_BASE64`: Base64-encoded app provisioning profile
- `EXTENSION_PROVISIONING_PROFILE_BASE64`: Base64-encoded extension provisioning profile
- `APPLE_ID`: Apple ID email
- `APP_SPECIFIC_PASSWORD`: App-specific password for Apple ID

See the [iOS Code Signing Guide](./docs/ios-code-signing.md) for detailed instructions on generating these secrets.

## Testing
This workflow should be tested by manually triggering it after setting up the required secrets.