### PR TITLE
Fix GitHub Pages screenshot artifacts display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ testflight-upload.log
 build-debug-report.json
 chrome-extension-*.zip
 test-results/
+
+# Generated showcase screenshots
+docs/screenshots/

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,5 +19,6 @@ relative_links:
 include:
   - index.html
   - images
+  - screenshots
   - "*.zip"
   - "*.ipa"

--- a/scripts/generate-showcase-page.js
+++ b/scripts/generate-showcase-page.js
@@ -1048,10 +1048,10 @@ class ShowcasePageGenerator {
                  lowerFile.includes('safari') && lowerPlatform.includes('safari') ||
                  lowerFile.includes('ios') && lowerPlatform.includes('ios');
         });
-        if (matchingFile) return matchingFile;
+        if (matchingFile) {return matchingFile;}
         
         // If no specific match, return the first screenshot found
-        if (files.length > 0) return files[0];
+        if (files.length > 0) {return files[0];}
       }
     }
     return null;
@@ -1085,9 +1085,9 @@ class ShowcasePageGenerator {
       return `
             <div class="screenshot-card">
                 ${screenshotFile ? 
-                  `<img src="./screenshots/${screenshotFile}" alt="Screenshot: ${platform.platform}" style="width: 100%; height: 200px; object-fit: cover;" onerror="this.parentElement.innerHTML='<div class=\\"screenshot-placeholder\\">Screenshot: ${platform.platform}</div>'" />` :
-                  `<div class="screenshot-placeholder">Screenshot: ${platform.platform}</div>`
-                }
+    `<img src="./screenshots/${screenshotFile}" alt="Screenshot: ${platform.platform}" style="width: 100%; height: 200px; object-fit: cover;" onerror="this.parentElement.innerHTML='<div class=\\"screenshot-placeholder\\">Screenshot: ${platform.platform}</div>'" />` :
+    `<div class="screenshot-placeholder">Screenshot: ${platform.platform}</div>`
+}
                 <div class="screenshot-info">
                     <h4>${platform.platform}</h4>
                     <p>${platform.platform_type === 'chrome_desktop' ? 'Desktop browser extension' : 'iOS Safari Web Extension'}</p>

--- a/scripts/generate-showcase-page.js
+++ b/scripts/generate-showcase-page.js
@@ -983,35 +983,7 @@ class ShowcasePageGenerator {
                 <h2>🌐 BrowserStack Multiplatform Testing</h2>
                 <p>BrowserStack test results not available</p>
                 <div class="screenshot-gallery">
-                    <div class="screenshot-card">
-                        <div class="screenshot-placeholder">
-                            Screenshot: Chrome on Windows 11
-                        </div>
-                        <div class="screenshot-info">
-                            <h4>Chrome on Windows 11</h4>
-                            <p>Desktop extension functionality testing</p>
-                        </div>
-                    </div>
-                    
-                    <div class="screenshot-card">
-                        <div class="screenshot-placeholder">
-                            Screenshot: Safari on iPhone 15 Pro
-                        </div>
-                        <div class="screenshot-info">
-                            <h4>Safari on iPhone 15 Pro</h4>
-                            <p>iOS Safari Web Extension testing</p>
-                        </div>
-                    </div>
-                    
-                    <div class="screenshot-card">
-                        <div class="screenshot-placeholder">
-                            Screenshot: Cross-platform sync demo
-                        </div>
-                        <div class="screenshot-info">
-                            <h4>Cross-Platform Sync</h4>
-                            <p>Real-time history synchronization between devices</p>
-                        </div>
-                    </div>
+                    ${this.generateFallbackScreenshots()}
                 </div>
             </div>`;
     }
@@ -1057,12 +1029,90 @@ class ShowcasePageGenerator {
         </div>`;
   }
 
-  generatePlatformScreenshots(platforms) {
-    return platforms.map(platform => `
+  findScreenshotForPlatform(platform) {
+    // Look for screenshots in test results directories
+    const screenshotDirs = [
+      'test-results/local-multiplatform/screenshots',
+      'test-results/browserstack/screenshots',
+      'test-results/screenshots'
+    ];
+    
+    for (const dir of screenshotDirs) {
+      if (fs.existsSync(dir)) {
+        const files = fs.readdirSync(dir).filter(f => f.endsWith('.png'));
+        // Try to find a screenshot that matches the platform name
+        const matchingFile = files.find(f => {
+          const lowerFile = f.toLowerCase();
+          const lowerPlatform = platform.platform?.toLowerCase() || '';
+          return lowerFile.includes('chrome') && lowerPlatform.includes('chrome') ||
+                 lowerFile.includes('safari') && lowerPlatform.includes('safari') ||
+                 lowerFile.includes('ios') && lowerPlatform.includes('ios');
+        });
+        if (matchingFile) return matchingFile;
+        
+        // If no specific match, return the first screenshot found
+        if (files.length > 0) return files[0];
+      }
+    }
+    return null;
+  }
+
+  generateFallbackScreenshots() {
+    // Try to find any available screenshots first
+    const availableScreenshots = this.findAllAvailableScreenshots();
+    
+    const fallbackPlatforms = [
+      { name: 'Chrome on Desktop', type: 'chrome_desktop', description: 'Desktop extension functionality testing' },
+      { name: 'Safari on iOS', type: 'safari_ios', description: 'iOS Safari Web Extension testing' },
+      { name: 'Cross-platform sync demo', type: 'sync_demo', description: 'Real-time history synchronization between devices' }
+    ];
+    
+    return fallbackPlatforms.map((platform, index) => {
+      const screenshotFile = availableScreenshots[index] || null;
+      
+      return `
             <div class="screenshot-card">
-                <div class="screenshot-placeholder">
-                    Screenshot: ${platform.platform}
+                ${screenshotFile ? 
+                  `<img src="./screenshots/${screenshotFile}" alt="Screenshot: ${platform.name}" style="width: 100%; height: 200px; object-fit: cover;" onerror="this.parentElement.innerHTML='<div class=\\"screenshot-placeholder\\">Screenshot: ${platform.name}</div>'" />` :
+                  `<div class="screenshot-placeholder">Screenshot: ${platform.name}</div>`
+                }
+                <div class="screenshot-info">
+                    <h4>${platform.name}</h4>
+                    <p>${platform.description}</p>
                 </div>
+            </div>
+        `;
+    }).join('');
+  }
+
+  findAllAvailableScreenshots() {
+    const screenshotDirs = [
+      'test-results/local-multiplatform/screenshots',
+      'test-results/browserstack/screenshots', 
+      'test-results/screenshots'
+    ];
+    
+    const allScreenshots = [];
+    for (const dir of screenshotDirs) {
+      if (fs.existsSync(dir)) {
+        const files = fs.readdirSync(dir).filter(f => f.endsWith('.png'));
+        allScreenshots.push(...files);
+      }
+    }
+    return allScreenshots;
+  }
+
+  generatePlatformScreenshots(platforms) {
+    return platforms.map(platform => {
+      // Look for actual screenshots for this platform
+      const screenshotFile = this.findScreenshotForPlatform(platform);
+      
+      return `
+            <div class="screenshot-card">
+                ${screenshotFile ? 
+                  `<img src="./screenshots/${screenshotFile}" alt="Screenshot: ${platform.platform}" style="width: 100%; height: 200px; object-fit: cover;" onerror="this.parentElement.innerHTML='<div class=\\"screenshot-placeholder\\">Screenshot: ${platform.platform}</div>'" />` :
+                  `<div class="screenshot-placeholder">Screenshot: ${platform.platform}</div>`
+                }
                 <div class="screenshot-info">
                     <h4>${platform.platform}</h4>
                     <p>${platform.platform_type === 'chrome_desktop' ? 'Desktop browser extension' : 'iOS Safari Web Extension'}</p>
@@ -1072,7 +1122,8 @@ class ShowcasePageGenerator {
                     </div>
                 </div>
             </div>
-        `).join('');
+        `;
+    }).join('');
   }
 
   generateP2PDemo() {
@@ -1264,6 +1315,40 @@ class ShowcasePageGenerator {
     return path.join(this.outputDir, 'index.html');
   }
 
+  copyScreenshots() {
+    const screenshotDirs = [
+      'test-results/local-multiplatform/screenshots',
+      'test-results/browserstack/screenshots',
+      'test-results/screenshots'
+    ];
+    
+    const outputScreenshotDir = path.join(this.outputDir, 'screenshots');
+    if (!fs.existsSync(outputScreenshotDir)) {
+      fs.mkdirSync(outputScreenshotDir, { recursive: true });
+    }
+    
+    let copiedCount = 0;
+    for (const dir of screenshotDirs) {
+      if (fs.existsSync(dir)) {
+        const files = fs.readdirSync(dir).filter(f => f.endsWith('.png'));
+        files.forEach(file => {
+          const sourcePath = path.join(dir, file);
+          const destPath = path.join(outputScreenshotDir, file);
+          try {
+            fs.copyFileSync(sourcePath, destPath);
+            copiedCount++;
+          } catch (error) {
+            console.warn(`⚠️ Failed to copy screenshot ${file}: ${error.message}`);
+          }
+        });
+      }
+    }
+    
+    if (copiedCount > 0) {
+      console.log(`📸 Copied ${copiedCount} screenshots to GitHub Pages`);
+    }
+  }
+
   copyArtifacts() {
     // Copy Chrome extension if available
     const chromeZip = `chrome-extension-${this.commitSha}.zip`;
@@ -1284,6 +1369,9 @@ class ShowcasePageGenerator {
       fs.copyFileSync('dist/trystero-bundle.js', path.join(this.outputDir, 'trystero-bundle.js'));
       console.log('🔗 Copied Trystero P2P bundle');
     }
+
+    // Copy screenshots from test results
+    this.copyScreenshots();
 
     // Copy any additional assets
     if (fs.existsSync('chrome-extension/images')) {

--- a/scripts/generate-showcase-page.js
+++ b/scripts/generate-showcase-page.js
@@ -1058,49 +1058,24 @@ class ShowcasePageGenerator {
   }
 
   generateFallbackScreenshots() {
-    // Try to find any available screenshots first
-    const availableScreenshots = this.findAllAvailableScreenshots();
-    
+    // When no BrowserStack results are available, show only placeholders
     const fallbackPlatforms = [
       { name: 'Chrome on Desktop', type: 'chrome_desktop', description: 'Desktop extension functionality testing' },
       { name: 'Safari on iOS', type: 'safari_ios', description: 'iOS Safari Web Extension testing' },
       { name: 'Cross-platform sync demo', type: 'sync_demo', description: 'Real-time history synchronization between devices' }
     ];
     
-    return fallbackPlatforms.map((platform, index) => {
-      const screenshotFile = availableScreenshots[index] || null;
-      
-      return `
+    return fallbackPlatforms.map(platform => `
             <div class="screenshot-card">
-                ${screenshotFile ? 
-                  `<img src="./screenshots/${screenshotFile}" alt="Screenshot: ${platform.name}" style="width: 100%; height: 200px; object-fit: cover;" onerror="this.parentElement.innerHTML='<div class=\\"screenshot-placeholder\\">Screenshot: ${platform.name}</div>'" />` :
-                  `<div class="screenshot-placeholder">Screenshot: ${platform.name}</div>`
-                }
+                <div class="screenshot-placeholder">Screenshot: ${platform.name}</div>
                 <div class="screenshot-info">
                     <h4>${platform.name}</h4>
                     <p>${platform.description}</p>
                 </div>
             </div>
-        `;
-    }).join('');
+        `).join('');
   }
 
-  findAllAvailableScreenshots() {
-    const screenshotDirs = [
-      'test-results/local-multiplatform/screenshots',
-      'test-results/browserstack/screenshots', 
-      'test-results/screenshots'
-    ];
-    
-    const allScreenshots = [];
-    for (const dir of screenshotDirs) {
-      if (fs.existsSync(dir)) {
-        const files = fs.readdirSync(dir).filter(f => f.endsWith('.png'));
-        allScreenshots.push(...files);
-      }
-    }
-    return allScreenshots;
-  }
 
   generatePlatformScreenshots(platforms) {
     return platforms.map(platform => {


### PR DESCRIPTION
## Summary
• Fix GitHub Pages site to display actual test screenshots instead of placeholder divs
• Screenshots are generated during CI/CD and deployed via GitHub Pages (not committed to git)
• Add intelligent screenshot detection and platform matching
• Update GitHub Pages configuration to serve screenshots directory

## Test plan
- [x] Screenshots are copied from test-results to docs/screenshots/ during CI
- [x] GitHub Pages _config.yml includes screenshots directory  
- [x] Generated showcase page uses real images with fallback to placeholders
- [x] Screenshot detection works for Chrome, Safari, and iOS platforms
- [x] Graceful handling when no screenshots are available
- [x] Screenshots are gitignored to prevent bloating repository

## Details
The GitHub Pages showcase site was showing hardcoded placeholder screenshots instead of actual test artifacts. This PR fixes the issue by:

1. **Screenshot Detection**: Added methods to find and match screenshots from test result directories
2. **CI/CD Integration**: Copy PNG screenshots from `test-results/` to `docs/screenshots/` during showcase page generation
3. **Smart Rendering**: Use real screenshots when available, fall back to placeholders when not
4. **GitHub Pages Config**: Updated `_config.yml` to serve the screenshots directory
5. **Git Hygiene**: Added `docs/screenshots/` to `.gitignore` to prevent committing generated artifacts

## Architecture
Screenshots are generated and deployed as follows:
1. **CI runs tests** → Screenshots saved to `test-results/local-multiplatform/screenshots/`
2. **Showcase generation** → Screenshots copied to `docs/screenshots/` 
3. **GitHub Pages deployment** → Entire `docs/` directory deployed (including screenshots)
4. **Git stays clean** → Screenshots never committed thanks to `.gitignore`

## Files Changed
- `scripts/generate-showcase-page.js`: Add screenshot detection, copying, and rendering logic
- `docs/_config.yml`: Include screenshots directory in GitHub Pages serving
- `.gitignore`: Prevent committing generated screenshot artifacts

This approach ensures users see real extension screenshots while keeping the repository clean and avoiding binary bloat in git history.

🤖 Generated with [Claude Code](https://claude.ai/code)