### PR TITLE
Add iOS Screenshot Collection to Multiplatform Testing

### DIFF
--- a/scripts/collect-debug-info.js
+++ b/scripts/collect-debug-info.js
@@ -66,6 +66,16 @@ function collectLogInfo() {
     };
   }
     
+  // Collect local multiplatform test log info
+  if (fs.existsSync('local-multiplatform-test-output.log')) {
+    const localMultiLogSize = execSync('wc -l < local-multiplatform-test-output.log', { encoding: 'utf8' }).trim();
+    const localMultiLogExcerpt = execSync('tail -20 local-multiplatform-test-output.log | jq -R . | jq -s .', { encoding: 'utf8' });
+    logs.local_multiplatform_test_log = {
+      size_lines: parseInt(localMultiLogSize),
+      excerpt: JSON.parse(localMultiLogExcerpt)
+    };
+  }
+
   // Collect TestFlight upload log info
   if (fs.existsSync('testflight-upload.log')) {
     const testflightLogSize = execSync('wc -l < testflight-upload.log', { encoding: 'utf8' }).trim();


### PR DESCRIPTION
## Summary
- Add comprehensive iOS screenshot collection during multiplatform testing
- Fix missing local multiplatform test log collection in debug reporting

## Test plan
- [x] Add takeIOSScreenshot() method using xcrun simctl
- [x] Capture screenshots at 5 key testing points during iOS Safari testing
- [x] Screenshots saved to same directory as Chrome screenshots for CI/CD collection
- [x] Add missing local multiplatform test log collection to debug script
- [x] Test that iOS screenshots are collected alongside Chrome screenshots during simultaneous P2P testing

🤖 Generated with [Claude Code](https://claude.ai/code)