### PR TITLE
Improve testing reliability and documentation completeness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,11 @@ npm run ios-build-testflight   # TestFlight build with upload
 
 # Clean build artifacts
 npm run clean
+
+# Code quality and linting
+npm run lint                   # Check code style and quality
+npm run lint:fix               # Auto-fix linting issues
+npm run lint:check             # Check with zero warnings tolerance
 ```
 
 ## Architecture Overview

--- a/test/local-multiplatform-test.js
+++ b/test/local-multiplatform-test.js
@@ -65,7 +65,7 @@ class LocalMultiplatformSyncTester {
     await Promise.race([
       page.screenshot({ path: filepath, fullPage: true }),
       new Promise((_, reject) => 
-        setTimeout(() => reject(new Error('Screenshot timeout after 15s')), 15000)
+        setTimeout(() => reject(new Error('Screenshot timeout after 60s')), 60000)
       )
     ]);
         


### PR DESCRIPTION
## Summary
- Increase Chrome extension screenshot timeout from 15s to 60s to address CI test failures
- Add missing ESLint commands to CLAUDE.md for complete development workflow documentation

## Test plan
- [ ] Verify Chrome extension tests run more reliably with longer screenshot timeout
- [ ] Confirm ESLint commands work as documented: `npm run lint`, `npm run lint:fix`, `npm run lint:check`
- [ ] Test all documented commands in CLAUDE.md still function correctly

🤖 Generated with [Claude Code](https://claude.ai/code)