### PR TITLE
Implement search-focused interface for article content

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,11 +58,18 @@ npm run lint:check             # Check with zero warnings tolerance
 
 ### Core Components
 1. **Background Service** (`background.js`): Manages P2P connections, history synchronization, and device coordination
-2. **Content Script** (`content.js`): Tracks page visits, navigation timing, and sends events to background
-3. **Popup Interface** (`popup.html/js/css`): Room configuration, connection status, and history management
+2. **Content Script** (`content.js`): Tracks page visits, extracts article content using Readability.js, and sends events to background
+3. **Popup Interface** (`popup.html/js/css`): Room configuration, connection status, and article search functionality
+
+### Article Content Extraction
+- **Readability.js Integration**: Mozilla Readability.js extracts clean article content from web pages
+- **Content Analysis**: Identifies articles vs. regular pages based on content length and structure
+- **Reading Time Calculation**: Estimates reading time at ~200 words per minute
+- **Search Interface**: Search through article titles, content, and excerpts via popup interface
 
 ### Build System
 - **Trystero Bundling**: `npm run build-trystero-bundle` creates IIFE bundle for both platforms
+- **Readability Bundling**: `npm run build-readability-bundle` creates IIFE bundle for article extraction
 - **Asset Copying**: Shared images and resources copied between platform directories
 - **Cross-Platform**: Single build command supports both Safari and Chrome outputs
 
@@ -115,10 +122,39 @@ npm run ci:collect-debug      # Collect debugging information
 npm run ci:generate-showcase  # Generate showcase documentation
 ```
 
+## Article Search Functionality
+
+### Using the Search Interface
+The extension provides a search-focused interface for finding articles by content:
+
+1. **Search Entry**: Type keywords in the search box to find relevant articles
+2. **Content Matching**: Search looks through article titles, content, URLs, and excerpts
+3. **Article Display**: Results show reading time, excerpts, and article badges
+4. **Clean Interface**: No history dump by default - only shows search results
+
+### Search Features
+- **Real-time Search**: Type keywords to find articles containing those terms
+- **Article Detection**: Only content identified as articles (>500 chars) gets special treatment
+- **Reading Time**: Shows estimated reading time based on word count (~200 WPM)
+- **Content Excerpts**: Preview first few sentences of extracted article content
+- **Cross-Platform**: Same search interface works on both Safari iOS and Chrome extensions
+
+### Testing Article Extraction
+```bash
+# Build extension with article extraction
+npm run build
+
+# Test on various content types
+# - News articles (should show article badge + reading time)
+# - Blog posts (should extract clean content)
+# - Social media (may not trigger article detection)
+# - Documentation pages (depends on structure)
+```
+
 ## Current Branch Context
 
-The current branch `replace-peerjs-with-trystero` represents the migration from PeerJS to Trystero for improved reliability and performance. Key changes include:
-- Trystero bundle integration replacing PeerJS
-- Updated build process for cross-platform support
-- Enhanced Chrome MV3 compatibility with offscreen documents
-- Improved connection reliability and debugging capabilities
+The current branch focuses on smart history search with article content extraction:
+- Readability.js integration for clean article content extraction
+- Search-focused popup interface for both Safari and Chrome extensions  
+- Enhanced history entries with reading time and content excerpts
+- Cross-platform article search functionality

--- a/README.md
+++ b/README.md
@@ -106,9 +106,12 @@ npm run clean
 - **Zero Server Setup**: Uses Trystero for serverless P2P connections
 - **Real-Time Sync**: Instant history sharing as you browse
 - **Privacy-First**: Direct P2P connections, no data stored on servers
+- **Article Extraction**: Automatic content extraction from articles using Readability.js
+- **Smart Search**: Search through article content, titles, and excerpts
+- **Reading Time**: Calculates estimated reading time for articles (~200 WPM)
 - **Duration Tracking**: Tracks time spent on each page
 - **Device Management**: Persistent device IDs for reconnection
-- **History Viewing**: Browse synced history from all connected devices
+- **Search-Focused Interface**: Clean popup focused on finding specific articles
 - **Easy Setup**: Just enter a shared room secret
 - **Live Demo**: Real P2P viewer embedded in showcase page
 
@@ -160,10 +163,17 @@ npm run test-local-multiplatform  # Chrome + Safari simulator testing
 2. **Configure**: Click extension icon → Enter room secret
 3. **Connect**: Click "Connect" to join the P2P network
 
-### Usage
-4. **Browse**: Visit any websites - history syncs automatically
-5. **View History**: Use "View History" to see synced data from all devices
-6. **Manage**: Use "Clear Local" or "Delete Remote" as needed
+### Using Article Search
+4. **Browse**: Visit articles and blog posts - content extracts automatically
+5. **Search**: Open extension → Type keywords to find articles by content
+6. **Results**: See articles with reading time estimates and content excerpts
+7. **Manage**: Use "Clear Local" or "Delete Remote" as needed
+
+### What Gets Extracted
+- **Article Content**: Clean text from news articles, blog posts, documentation
+- **Reading Time**: Estimated at ~200 words per minute
+- **Excerpts**: First few sentences for quick preview
+- **Article Detection**: Only content >500 characters gets article treatment
 
 ## 🔒 Security
 

--- a/bar123 Extension/Resources/popup.css
+++ b/bar123 Extension/Resources/popup.css
@@ -316,4 +316,80 @@ button {
     .empty-state {
         color: #9ca3af;
     }
+    
+    .article-badge {
+        color: #60a5fa;
+    }
+    
+    .article-excerpt {
+        color: #9ca3af;
+    }
+}
+
+/* Search section */
+.search-section {
+    margin-bottom: 16px;
+    border-bottom: 1px solid #e5e7eb;
+    padding-bottom: 16px;
+}
+
+.search-controls {
+    display: flex;
+    gap: 8px;
+    margin-top: 8px;
+}
+
+.search-controls input {
+    flex: 1;
+    min-width: 0;
+}
+
+.search-controls button {
+    flex-shrink: 0;
+    padding: 6px 12px;
+    font-size: 12px;
+}
+
+/* Article content styling */
+.article-info {
+    margin-top: 4px;
+    font-size: 11px;
+}
+
+.article-badge {
+    background: #e0f2fe;
+    color: #0369a1;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 10px;
+    font-weight: 500;
+}
+
+.article-excerpt {
+    color: #6b7280;
+    margin-top: 4px;
+    line-height: 1.3;
+    font-style: italic;
+}
+
+.search-prompt {
+    text-align: center;
+    color: #9ca3af;
+    font-style: italic;
+    padding: 20px;
+}
+
+@media (prefers-color-scheme: dark) {
+    .search-section {
+        border-bottom-color: #4b5563;
+    }
+    
+    .article-badge {
+        background: #1e3a8a;
+        color: #93c5fd;
+    }
+    
+    .search-prompt {
+        color: #6b7280;
+    }
 }

--- a/bar123 Extension/Resources/popup.html
+++ b/bar123 Extension/Resources/popup.html
@@ -40,10 +40,15 @@
             <div>Last sync: <span id="lastSync">Never</span></div>
         </div>
 
-        <div class="history-section">
-            <h3>History <button id="refreshHistoryBtn" class="refresh-btn">↻</button></h3>
+        <div class="search-section">
+            <h3>Search History</h3>
+            <div class="search-controls">
+                <input type="text" id="searchInput" placeholder="Search articles by title or content...">
+                <button id="searchBtn" class="secondary">Search</button>
+                <button id="clearSearchBtn" class="secondary">Clear</button>
+            </div>
             <div id="historyList" class="history-list">
-                <div class="empty-state">No history entries yet</div>
+                <div class="search-prompt">Enter search terms to find articles</div>
             </div>
         </div>
 

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,25 +1,152 @@
-// Chrome extension content script for history tracking only
-console.log('History Sync content script loaded');
+class HistoryTracker {
+  constructor() {
+    this.lastUrl = window.location.href;
+    this.startTime = Date.now();
+    this.init();
+  }
 
-// Track page visits
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', trackPageVisit);
-} else {
-  trackPageVisit();
+  init() {
+    this.trackPageVisit();
+    this.setupNavigationTracking();
+        
+    // Use chrome instead of browser for Chrome extension
+    chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+      if (request.action === 'getPageInfo') {
+        sendResponse({
+          url: window.location.href,
+          title: document.title,
+          visitTime: Date.now()
+        });
+      }
+    });
+  }
+
+  extractArticleContent() {
+    try {
+      // Clone the document for Readability
+      const documentClone = document.cloneNode(true);
+      const reader = new Readability(documentClone);
+      const article = reader.parse();
+      
+      if (article) {
+        console.log('📖 Extracted article content:', {
+          title: article.title,
+          contentLength: article.textContent?.length || 0,
+          excerpt: article.excerpt
+        });
+        
+        return {
+          title: article.title,
+          content: article.textContent,
+          excerpt: article.excerpt,
+          length: article.length,
+          readingTime: Math.ceil((article.textContent?.split(' ').length || 0) / 200), // ~200 WPM
+          isArticle: article.length > 500
+        };
+      }
+      
+      return null;
+    } catch (error) {
+      console.warn('Failed to extract article content:', error);
+      return null;
+    }
+  }
+
+  trackPageVisit() {
+    const basicEntry = {
+      url: window.location.href,
+      title: document.title,
+      visitTime: Date.now(),
+      duration: 0,
+      hostname: window.location.hostname,
+      pathname: window.location.pathname
+    };
+
+    // Extract article content if possible
+    const articleContent = this.extractArticleContent();
+    
+    const historyEntry = {
+      ...basicEntry,
+      articleContent: articleContent
+    };
+
+    console.log('🌐 Content script tracking page visit:', historyEntry);
+
+    chrome.runtime.sendMessage({
+      action: 'trackHistory',
+      entry: historyEntry
+    }).then((response) => {
+      console.log('✅ History tracking successful:', response);
+    }).catch(err => {
+      console.log('❌ History tracking failed:', err);
+    });
+  }
+
+  setupNavigationTracking() {
+    let observer;
+
+    const trackNavigation = () => {
+      const currentUrl = window.location.href;
+      if (currentUrl !== this.lastUrl) {
+        const duration = Date.now() - this.startTime;
+                
+        chrome.runtime.sendMessage({
+          action: 'updateDuration',
+          url: this.lastUrl,
+          duration: duration
+        }).catch(err => {
+          console.log('Duration update failed:', err);
+        });
+
+        this.lastUrl = currentUrl;
+        this.startTime = Date.now();
+        this.trackPageVisit();
+      }
+    };
+
+    if (typeof MutationObserver !== 'undefined') {
+      observer = new MutationObserver(() => {
+        setTimeout(trackNavigation, 100);
+      });
+            
+      observer.observe(document, {
+        childList: true,
+        subtree: true
+      });
+    }
+
+    window.addEventListener('popstate', trackNavigation);
+    window.addEventListener('pushstate', trackNavigation);
+    window.addEventListener('replacestate', trackNavigation);
+
+    const originalPushState = history.pushState;
+    const originalReplaceState = history.replaceState;
+
+    history.pushState = function(...args) {
+      originalPushState.apply(history, args);
+      window.dispatchEvent(new Event('pushstate'));
+    };
+
+    history.replaceState = function(...args) {
+      originalReplaceState.apply(history, args);
+      window.dispatchEvent(new Event('replacestate'));
+    };
+
+    window.addEventListener('beforeunload', () => {
+      const duration = Date.now() - this.startTime;
+      chrome.runtime.sendMessage({
+        action: 'updateDuration',
+        url: this.lastUrl,
+        duration: duration
+      }).catch(() => {});
+    });
+  }
 }
 
-function trackPageVisit() {
-  const historyEntry = {
-    url: window.location.href,
-    title: document.title,
-    visitTime: Date.now()
-  };
-    
-  // Send to background script
-  chrome.runtime.sendMessage({
-    action: 'trackHistory',
-    entry: historyEntry
-  }).catch(error => {
-    console.log('Failed to track history:', error);
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', () => {
+    new HistoryTracker();
   });
+} else {
+  new HistoryTracker();
 }

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -17,7 +17,7 @@
   "content_scripts": [{
     "js": ["readability-bundle.js", "content.js"],
     "matches": ["<all_urls>"],
-    "run_at": "document_start"
+    "run_at": "document_idle"
   }],
   
   "action": {

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -26,12 +26,13 @@
             color: #721c24;
         }
         
-        input[type="password"] {
+        input {
             width: 100%;
             padding: 8px;
             border: 1px solid #ddd;
             border-radius: 4px;
             margin-bottom: 8px;
+            box-sizing: border-box;
         }
         
         button {
@@ -51,6 +52,95 @@
             background: #6c757d;
             color: white;
         }
+
+        .search-section {
+            margin-top: 16px;
+            border-top: 1px solid #ddd;
+            padding-top: 16px;
+        }
+
+        .search-controls {
+            display: flex;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .search-controls input {
+            flex: 1;
+            margin-bottom: 0;
+        }
+
+        .search-controls button {
+            flex-shrink: 0;
+            padding: 6px 12px;
+            font-size: 12px;
+            margin-right: 0;
+        }
+
+        .history-list {
+            max-height: 200px;
+            overflow-y: auto;
+            font-size: 12px;
+            margin-top: 8px;
+        }
+
+        .history-entry {
+            border-bottom: 1px solid #eee;
+            padding: 8px 0;
+        }
+
+        .history-title {
+            font-weight: bold;
+            color: #007bff;
+            margin-bottom: 2px;
+        }
+
+        .history-url {
+            color: #666;
+            font-size: 10px;
+            margin-bottom: 2px;
+        }
+
+        .article-info {
+            margin: 4px 0;
+            font-size: 11px;
+        }
+
+        .article-badge {
+            background: #e0f2fe;
+            color: #0369a1;
+            padding: 2px 6px;
+            border-radius: 4px;
+            font-size: 10px;
+            font-weight: 500;
+        }
+
+        .article-excerpt {
+            color: #6b7280;
+            margin-top: 4px;
+            line-height: 1.3;
+            font-style: italic;
+        }
+
+        .history-meta {
+            color: #999;
+            font-size: 10px;
+            margin-top: 2px;
+        }
+
+        .search-prompt {
+            text-align: center;
+            color: #999;
+            font-style: italic;
+            padding: 20px;
+        }
+
+        .empty-state {
+            text-align: center;
+            color: #999;
+            font-style: italic;
+            padding: 20px;
+        }
     </style>
 </head>
 <body>
@@ -64,12 +154,16 @@
     <button id="connectBtn" class="primary">Connect</button>
     <button id="disconnectBtn" class="secondary" style="display: none;">Disconnect</button>
     
-    <div id="historySection" style="margin-top: 16px;">
-        <h4>Synced History</h4>
-        <div id="historyList" style="max-height: 200px; overflow-y: auto; font-size: 12px;">
-            <div id="noHistory" style="color: #666; font-style: italic;">No history entries yet</div>
+    <div class="search-section">
+        <h4>Search History</h4>
+        <div class="search-controls">
+            <input type="text" id="searchInput" placeholder="Search articles by title or content...">
+            <button id="searchBtn" class="secondary">Search</button>
+            <button id="clearSearchBtn" class="secondary">Clear</button>
         </div>
-        <button id="refreshBtn" class="secondary" style="margin-top: 8px; font-size: 12px;">Refresh</button>
+        <div id="historyList" class="history-list">
+            <div class="search-prompt">Enter search terms to find articles</div>
+        </div>
     </div>
 
     <script src="popup.js"></script>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -3,11 +3,14 @@ document.addEventListener('DOMContentLoaded', function() {
   const sharedSecretInput = document.getElementById('sharedSecret');
   const connectBtn = document.getElementById('connectBtn');
   const disconnectBtn = document.getElementById('disconnectBtn');
-  const refreshBtn = document.getElementById('refreshBtn');
+  const searchInput = document.getElementById('searchInput');
+  const searchBtn = document.getElementById('searchBtn');
+  const clearSearchBtn = document.getElementById('clearSearchBtn');
+  const historyList = document.getElementById('historyList');
     
   // Load initial state
   updateUI();
-  loadHistory();
+  showSearchPrompt();
     
   connectBtn.addEventListener('click', async () => {
     const secret = sharedSecretInput.value.trim();
@@ -43,8 +46,18 @@ document.addEventListener('DOMContentLoaded', function() {
     updateUI();
   });
     
-  refreshBtn.addEventListener('click', () => {
-    loadHistory();
+  searchBtn.addEventListener('click', () => {
+    searchHistory();
+  });
+
+  clearSearchBtn.addEventListener('click', () => {
+    clearSearch();
+  });
+
+  searchInput.addEventListener('keyup', (e) => {
+    if (e.key === 'Enter') {
+      searchHistory();
+    }
   });
     
   async function updateUI() {
@@ -71,51 +84,137 @@ document.addEventListener('DOMContentLoaded', function() {
     }
   }
     
-  async function loadHistory() {
+  function showSearchPrompt() {
+    if (historyList) {
+      historyList.innerHTML = '<div class="search-prompt">Enter search terms to find articles</div>';
+    }
+  }
+
+  function getSearchableText(entry) {
+    const parts = [
+      entry.title || '',
+      entry.url || '',
+      entry.articleContent?.title || '',
+      entry.articleContent?.content || '',
+      entry.articleContent?.excerpt || ''
+    ];
+    return parts.join(' ').toLowerCase();
+  }
+
+  function truncateText(text, maxLength) {
+    if (!text || text.length <= maxLength) {
+      return text;
+    }
+    return text.substring(0, maxLength) + '...';
+  }
+
+  function truncateUrl(url) {
     try {
-      const response = await chrome.runtime.sendMessage({ action: 'getHistory' });
+      const urlObj = new URL(url);
+      const domain = urlObj.hostname;
+      return url.length > 35 ? domain + '...' : url;
+    } catch {
+      return url.length > 35 ? url.substring(0, 35) + '...' : url;
+    }
+  }
+
+  function getTimeAgo(date) {
+    const now = new Date();
+    const seconds = Math.floor((now - date) / 1000);
+        
+    if (seconds < 60) {return `${seconds}s ago`;}
+    if (seconds < 3600) {return `${Math.floor(seconds / 60)}m ago`;}
+    if (seconds < 86400) {return `${Math.floor(seconds / 3600)}h ago`;}
+    return `${Math.floor(seconds / 86400)}d ago`;
+  }
+
+  function displayHistory(historyEntries) {
+    if (!historyEntries || historyEntries.length === 0) {
+      historyList.innerHTML = '<div class="empty-state">No history entries yet</div>';
+      return;
+    }
+
+    // Sort by visit time (newest first)
+    const sortedHistory = historyEntries.sort((a, b) => (b.visitTime || 0) - (a.visitTime || 0));
+
+    // Limit to last 20 entries for performance
+    const recentHistory = sortedHistory.slice(0, 20);
+
+    const historyHTML = recentHistory.map(entry => {
+      const isLocal = !entry.synced || entry.sourceDevice === entry.deviceId;
+      const entryClass = isLocal ? 'local' : 'synced';
             
-      const historyList = document.getElementById('historyList');
-      const noHistory = document.getElementById('noHistory');
-      
-      if (!historyList) {
-        console.error('historyList element not found');
-        return;
+      const visitTime = new Date(entry.visitTime || 0);
+      const timeAgo = getTimeAgo(visitTime);
+            
+      const duration = entry.duration ? `${Math.round(entry.duration / 1000)}s` : '';
+      const source = isLocal ? 'Local' : 'Synced';
+
+      // Article content display
+      const articleContent = entry.articleContent;
+      let articleInfo = '';
+      if (articleContent && articleContent.isArticle) {
+        const readingTime = articleContent.readingTime;
+        const excerpt = articleContent.excerpt ? truncateText(articleContent.excerpt, 100) : '';
+        articleInfo = `
+          <div class="article-info">
+            <span class="article-badge">📖 Article • ${readingTime} min read</span>
+            ${excerpt ? `<div class="article-excerpt">${excerpt}</div>` : ''}
+          </div>
+        `;
       }
             
-      if (response.success && response.history && response.history.length > 0) {
-        if (noHistory) {
-          noHistory.style.display = 'none';
+      return `
+        <div class="history-entry ${entryClass}" data-search-content="${getSearchableText(entry)}">
+          <div class="history-title" title="${entry.title || ''}">${entry.title || 'Untitled'}</div>
+          <div class="history-url" title="${entry.url || ''}">${truncateUrl(entry.url || '')}</div>
+          ${articleInfo}
+          <div class="history-meta">
+            <span>${source}</span> • <span>${timeAgo} ${duration ? `• ${duration}` : ''}</span>
+          </div>
+        </div>
+      `;
+    }).join('');
+
+    historyList.innerHTML = historyHTML;
+  }
+
+  async function searchHistory() {
+    const query = searchInput.value.trim().toLowerCase();
+    
+    if (!query) {
+      showSearchPrompt();
+      return;
+    }
+
+    try {
+      const response = await chrome.runtime.sendMessage({ 
+        action: 'getHistory' 
+      });
+      
+      if (response.success && response.history) {
+        // Filter history based on search query
+        const filteredHistory = response.history.filter(entry => {
+          const searchText = getSearchableText(entry);
+          return searchText.includes(query);
+        });
+        
+        displayHistory(filteredHistory);
+        
+        // Update UI to show search results
+        const resultCount = filteredHistory.length;
+        if (resultCount === 0) {
+          historyList.innerHTML = `<div class="empty-state">No results found for "${query}"</div>`;
         }
-        historyList.innerHTML = response.history.map(entry => {
-          const date = new Date(entry.visitTime).toLocaleString();
-          const sourceDevice = entry.sourceDevice ? ` (${entry.sourceDevice.split('_')[0]})` : '';
-          return `
-                        <div style="border-bottom: 1px solid #eee; padding: 4px 0;">
-                            <div style="font-weight: bold; color: #007bff;">
-                                ${entry.title || 'Untitled'}
-                            </div>
-                            <div style="color: #666; font-size: 10px;">
-                                ${entry.url}
-                            </div>
-                            <div style="color: #999; font-size: 10px;">
-                                ${date}${sourceDevice}
-                            </div>
-                        </div>
-                    `;
-        }).join('');
-      } else {
-        if (noHistory) {
-          noHistory.style.display = 'block';
-        }
-        historyList.innerHTML = '<div id="noHistory" style="color: #666; font-style: italic;">No history entries yet</div>';
       }
     } catch (error) {
-      console.error('Failed to load history:', error);
-      const historyList = document.getElementById('historyList');
-      if (historyList) {
-        historyList.innerHTML = '<div style="color: #d00;">Error loading history</div>';
-      }
+      console.error('Search failed:', error);
+      historyList.innerHTML = '<div class="empty-state">Search failed</div>';
     }
+  }
+
+  function clearSearch() {
+    searchInput.value = '';
+    showSearchPrompt();
   }
 });

--- a/scripts/launch-chrome-extension.js
+++ b/scripts/launch-chrome-extension.js
@@ -17,7 +17,7 @@ async function launchChromeWithExtension() {
     process.exit(1);
   }
     
-  const extensionPath = path.resolve(__dirname, 'chrome-extension');
+  const extensionPath = path.resolve(__dirname, '../chrome-extension');
   const userDataDir = path.join(__dirname, 'temp-chrome-profile-' + Date.now());
     
   console.log(`📂 Extension path: ${extensionPath}`);


### PR DESCRIPTION
Changes the extension to be search-first rather than displaying tons of history:
- Remove automatic history loading on startup
- Show search prompt instead of full history dump
- Focus interface on finding specific articles via search
- Clean initial state with "Enter search terms to find articles"
- Enhanced article display with reading time and excerpts
- Search through titles, content, URLs, and excerpts

🤖 Generated with [Claude Code](https://claude.ai/code)