### PR TITLE
Add Safari extension for encrypted history storage

### DIFF
--- a/EncryptedHistorySafari/ContentView.swift
+++ b/EncryptedHistorySafari/ContentView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+struct ContentView: View {
+    @AppStorage("encryptionSecret") private var encryptionSecret = ""
+    @AppStorage("pantryID") private var pantryID = ""
+    @AppStorage("pantryBasket") private var pantryBasket = "encrypted-history"
+    @AppStorage("syncIntervalHours") private var syncIntervalHours = 1.0
+    @State private var showingSecret = false
+    @State private var isSyncing = false
+    @State private var lastSyncTime: Date?
+    @State private var refreshTimer: Timer?
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Encrypted History Settings")
+                .font(.largeTitle)
+                .padding()
+            
+            Form {
+                Section(header: Text("Encryption")) {
+                    HStack {
+                        if showingSecret {
+                            TextField("Encryption Secret", text: $encryptionSecret)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                        } else {
+                            SecureField("Encryption Secret", text: $encryptionSecret)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                        }
+                        
+                        Button(action: { showingSecret.toggle() }) {
+                            Image(systemName: showingSecret ? "eye.slash" : "eye")
+                        }
+                    }
+                    
+                    Text("This secret is used to encrypt your browsing history")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                Section(header: Text("Pantry Configuration")) {
+                    TextField("Pantry ID", text: $pantryID)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    
+                    TextField("Basket Name", text: $pantryBasket)
+                        .textFieldStyle(RoundedBorderTextFieldStyle())
+                    
+                    Link("Get your Pantry ID", destination: URL(string: "https://getpantry.cloud")!)
+                        .font(.caption)
+                }
+                
+                Section(header: Text("Sync Settings")) {
+                    VStack(alignment: .leading) {
+                        Text("Sync Interval: \(Int(syncIntervalHours)) hour\(syncIntervalHours == 1 ? "" : "s")")
+                        Slider(value: $syncIntervalHours, in: 0.5...24, step: 0.5)
+                            .onChange(of: syncIntervalHours) { _ in
+                                // Notify the history manager to update timer
+                                NotificationCenter.default.post(name: NSNotification.Name("UpdateSyncInterval"), object: nil)
+                            }
+                    }
+                    
+                    Text("History older than 30 days is automatically removed")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                Section(header: Text("Sync Status")) {
+                    if let lastSync = lastSyncTime {
+                        Text("Last synced: \(lastSync, formatter: dateFormatter)")
+                    } else {
+                        Text("Not synced yet")
+                    }
+                    
+                    Button(action: syncNow) {
+                        if isSyncing {
+                            ProgressView()
+                                .progressViewStyle(CircularProgressViewStyle())
+                        } else {
+                            Text("Sync Now")
+                        }
+                    }
+                    .disabled(isSyncing || pantryID.isEmpty || encryptionSecret.isEmpty)
+                }
+            }
+            .padding()
+            
+            Text("History syncs automatically based on your interval or when you have 100+ entries")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .padding()
+        }
+        .frame(minWidth: 500, minHeight: 400)
+        .onAppear {
+            loadLastSyncTime()
+            // Update last sync time every 30 seconds
+            refreshTimer = Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { _ in
+                loadLastSyncTime()
+            }
+        }
+        .onDisappear {
+            refreshTimer?.invalidate()
+        }
+    }
+    
+    private func syncNow() {
+        isSyncing = true
+        
+        // Create and trigger sync directly
+        let secret = encryptionSecret.isEmpty ? "default-secret-change-me" : encryptionSecret
+        let historyManager = HistoryManager(secret: secret, pantryID: pantryID, pantryBasket: pantryBasket)
+        
+        Task {
+            await historyManager.syncToPantry()
+            
+            DispatchQueue.main.async {
+                self.isSyncing = false
+                self.loadLastSyncTime()
+            }
+        }
+    }
+    
+    private func loadLastSyncTime() {
+        lastSyncTime = UserDefaults.standard.object(forKey: "lastSyncTime") as? Date
+    }
+    
+    private var dateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/EncryptedHistorySafari/EncryptedHistoryApp.swift
+++ b/EncryptedHistorySafari/EncryptedHistoryApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct EncryptedHistoryApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/EncryptedHistorySafari/Extension/_locales/en/messages.json
+++ b/EncryptedHistorySafari/Extension/_locales/en/messages.json
@@ -1,0 +1,10 @@
+{
+  "extension_name": {
+    "message": "Encrypted History",
+    "description": "Name of the extension"
+  },
+  "extension_description": {
+    "message": "Stores browsing history encrypted with background sync",
+    "description": "Description of the extension"
+  }
+}

--- a/EncryptedHistorySafari/Extension/background.js
+++ b/EncryptedHistorySafari/Extension/background.js
@@ -1,0 +1,27 @@
+browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === 'complete' && tab.url) {
+    const historyEntry = {
+      url: tab.url,
+      title: tab.title || '',
+      timestamp: Date.now(),
+      tabId: tabId
+    };
+    
+    browser.runtime.sendNativeMessage("com.encryptedhistory.safari", {
+      action: "addHistory",
+      data: historyEntry
+    });
+  }
+});
+
+browser.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.action === "getHistory") {
+    browser.runtime.sendNativeMessage("com.encryptedhistory.safari", {
+      action: "getHistory",
+      filters: request.filters || {}
+    }, (response) => {
+      sendResponse(response);
+    });
+    return true;
+  }
+});

--- a/EncryptedHistorySafari/Extension/content.js
+++ b/EncryptedHistorySafari/Extension/content.js
@@ -1,0 +1,15 @@
+// Content script to capture additional page metadata if needed
+window.addEventListener('load', () => {
+  const pageData = {
+    url: window.location.href,
+    title: document.title,
+    description: document.querySelector('meta[name="description"]')?.content || '',
+    timestamp: Date.now()
+  };
+  
+  // Send to background script
+  browser.runtime.sendMessage({
+    action: "pageLoaded",
+    data: pageData
+  });
+});

--- a/EncryptedHistorySafari/Extension/manifest.json
+++ b/EncryptedHistorySafari/Extension/manifest.json
@@ -1,0 +1,37 @@
+{
+  "manifest_version": 3,
+  "default_locale": "en",
+  
+  "name": "__MSG_extension_name__",
+  "description": "__MSG_extension_description__",
+  "version": "1.0",
+  
+  "icons": {
+    "48": "images/icon-48.png",
+    "96": "images/icon-96.png",
+    "128": "images/icon-128.png",
+    "256": "images/icon-256.png",
+    "512": "images/icon-512.png"
+  },
+  
+  "background": {
+    "service_worker": "background.js",
+    "persistent": false
+  },
+  
+  "content_scripts": [{
+    "js": ["content.js"],
+    "matches": ["<all_urls>"],
+    "run_at": "document_start"
+  }],
+  
+  "permissions": ["nativeMessaging", "storage", "tabs"],
+  
+  "action": {
+    "default_popup": "popup.html",
+    "default_icon": {
+      "16": "images/icon-16.png",
+      "32": "images/icon-32.png"
+    }
+  }
+}

--- a/EncryptedHistorySafari/Extension/popup.html
+++ b/EncryptedHistorySafari/Extension/popup.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+            width: 400px;
+            padding: 10px;
+            margin: 0;
+        }
+        
+        h1 {
+            font-size: 18px;
+            margin-bottom: 10px;
+        }
+        
+        .history-item {
+            padding: 8px;
+            border-bottom: 1px solid #e0e0e0;
+            cursor: pointer;
+        }
+        
+        .history-item:hover {
+            background-color: #f5f5f5;
+        }
+        
+        .history-title {
+            font-weight: 500;
+            margin-bottom: 2px;
+        }
+        
+        .history-url {
+            font-size: 12px;
+            color: #666;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+        
+        .history-time {
+            font-size: 11px;
+            color: #999;
+            margin-top: 2px;
+        }
+        
+        #loading {
+            text-align: center;
+            padding: 20px;
+            color: #666;
+        }
+        
+        #error {
+            color: red;
+            padding: 10px;
+            text-align: center;
+        }
+        
+        .controls {
+            padding: 10px;
+            border-bottom: 1px solid #e0e0e0;
+        }
+        
+        button {
+            background: #007AFF;
+            color: white;
+            border: none;
+            padding: 6px 12px;
+            border-radius: 4px;
+            cursor: pointer;
+        }
+        
+        button:hover {
+            background: #0056b3;
+        }
+    </style>
+</head>
+<body>
+    <h1>Encrypted History</h1>
+    
+    <div class="controls">
+        <button id="refreshBtn">Refresh</button>
+        <button id="syncBtn">Sync Now</button>
+    </div>
+    
+    <div id="loading">Loading history...</div>
+    <div id="error" style="display: none;"></div>
+    <div id="historyList" style="display: none;"></div>
+    
+    <script src="popup.js"></script>
+</body>
+</html>

--- a/EncryptedHistorySafari/Extension/popup.js
+++ b/EncryptedHistorySafari/Extension/popup.js
@@ -1,0 +1,89 @@
+document.addEventListener('DOMContentLoaded', () => {
+    loadHistory();
+    
+    document.getElementById('refreshBtn').addEventListener('click', loadHistory);
+    document.getElementById('syncBtn').addEventListener('click', syncHistory);
+});
+
+function loadHistory() {
+    const loading = document.getElementById('loading');
+    const error = document.getElementById('error');
+    const historyList = document.getElementById('historyList');
+    
+    loading.style.display = 'block';
+    error.style.display = 'none';
+    historyList.style.display = 'none';
+    
+    browser.runtime.sendMessage({ action: 'getHistory' }, (response) => {
+        loading.style.display = 'none';
+        
+        if (response && response.history) {
+            displayHistory(response.history);
+        } else {
+            error.style.display = 'block';
+            error.textContent = 'Failed to load history';
+        }
+    });
+}
+
+function displayHistory(history) {
+    const historyList = document.getElementById('historyList');
+    historyList.innerHTML = '';
+    historyList.style.display = 'block';
+    
+    if (history.length === 0) {
+        historyList.innerHTML = '<div style="text-align: center; padding: 20px; color: #666;">No history found</div>';
+        return;
+    }
+    
+    // Sort by timestamp descending
+    history.sort((a, b) => b.timestamp - a.timestamp);
+    
+    history.forEach(item => {
+        const div = document.createElement('div');
+        div.className = 'history-item';
+        
+        const title = document.createElement('div');
+        title.className = 'history-title';
+        title.textContent = item.title || 'Untitled';
+        
+        const url = document.createElement('div');
+        url.className = 'history-url';
+        url.textContent = item.url;
+        
+        const time = document.createElement('div');
+        time.className = 'history-time';
+        time.textContent = new Date(item.timestamp).toLocaleString();
+        
+        div.appendChild(title);
+        div.appendChild(url);
+        div.appendChild(time);
+        
+        div.addEventListener('click', () => {
+            browser.tabs.create({ url: item.url });
+        });
+        
+        historyList.appendChild(div);
+    });
+}
+
+function syncHistory() {
+    const syncBtn = document.getElementById('syncBtn');
+    syncBtn.disabled = true;
+    syncBtn.textContent = 'Syncing...';
+    
+    browser.runtime.sendNativeMessage('com.encryptedhistory.safari', {
+        action: 'sync'
+    }, (response) => {
+        syncBtn.disabled = false;
+        syncBtn.textContent = 'Sync Now';
+        
+        if (response && response.success) {
+            loadHistory();
+        } else {
+            const error = document.getElementById('error');
+            error.style.display = 'block';
+            error.textContent = 'Sync failed';
+        }
+    });
+}

--- a/EncryptedHistorySafari/HistoryManager.swift
+++ b/EncryptedHistorySafari/HistoryManager.swift
@@ -1,0 +1,180 @@
+import Foundation
+import CryptoKit
+import SafariServices
+
+class HistoryManager {
+    private let encryptionKey: SymmetricKey
+    private let pantryBasket: String
+    private let pantryID: String
+    private var syncTimer: Timer?
+    private let expirationDays = 30
+    
+    init(secret: String, pantryID: String, pantryBasket: String) {
+        self.pantryID = pantryID
+        self.pantryBasket = pantryBasket
+        self.encryptionKey = SymmetricKey(data: SHA256.hash(data: secret.data(using: .utf8)!))
+        
+        // Start sync timer
+        startSyncTimer()
+        
+        // Listen for sync interval updates
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(updateSyncInterval),
+            name: NSNotification.Name("UpdateSyncInterval"),
+            object: nil
+        )
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
+    func startSyncTimer() {
+        syncTimer?.invalidate()
+        
+        let hours = UserDefaults.standard.double(forKey: "syncIntervalHours")
+        let interval = hours > 0 ? hours * 3600 : 3600 // Default to 1 hour
+        
+        syncTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
+            Task {
+                await self.syncToPantry()
+            }
+        }
+        
+        // Also sync immediately
+        Task {
+            await self.syncToPantry()
+        }
+    }
+    
+    @objc private func updateSyncInterval() {
+        startSyncTimer()
+    }
+    
+    func addHistoryEntry(_ entry: HistoryEntry) async {
+        var entries = await loadLocalHistory()
+        entries.append(entry)
+        await saveLocalHistory(entries)
+        
+        // Sync if we have more than 100 entries or it's been more than a day
+        if entries.count > 100 || shouldSyncBasedOnTime() {
+            await syncToPantry()
+        }
+    }
+    
+    private func shouldSyncBasedOnTime() -> Bool {
+        let lastSync = UserDefaults.standard.object(forKey: "lastSyncTime") as? Date ?? Date.distantPast
+        return Date().timeIntervalSince(lastSync) > 86400 // 24 hours
+    }
+    
+    private func loadLocalHistory() async -> [HistoryEntry] {
+        guard let data = UserDefaults.standard.data(forKey: "localHistory") else { return [] }
+        
+        do {
+            let decrypted = try decrypt(data)
+            var entries = try JSONDecoder().decode([HistoryEntry].self, from: decrypted)
+            
+            // Remove expired entries (older than 30 days)
+            let cutoffDate = Calendar.current.date(byAdding: .day, value: -expirationDays, to: Date())!
+            entries = entries.filter { $0.timestamp > cutoffDate }
+            
+            return entries
+        } catch {
+            print("Failed to load local history: \(error)")
+            return []
+        }
+    }
+    
+    private func saveLocalHistory(_ entries: [HistoryEntry]) async {
+        do {
+            let data = try JSONEncoder().encode(entries)
+            let encrypted = try encrypt(data)
+            UserDefaults.standard.set(encrypted, forKey: "localHistory")
+        } catch {
+            print("Failed to save local history: \(error)")
+        }
+    }
+    
+    private func encrypt(_ data: Data) throws -> Data {
+        let sealed = try AES.GCM.seal(data, using: encryptionKey)
+        return sealed.combined!
+    }
+    
+    private func decrypt(_ data: Data) throws -> Data {
+        let sealed = try AES.GCM.SealedBox(combined: data)
+        return try AES.GCM.open(sealed, using: encryptionKey)
+    }
+    
+    func syncToPantry() async {
+        let entries = await loadLocalHistory()
+        guard !entries.isEmpty else { return }
+        
+        do {
+            let data = try JSONEncoder().encode(entries)
+            let encrypted = try encrypt(data)
+            
+            // Upload to Pantry
+            let url = URL(string: "https://getpantry.cloud/apiv1/pantry/\(pantryID)/basket/\(pantryBasket)")!
+            var request = URLRequest(url: url)
+            request.httpMethod = "PUT"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            
+            let payload = ["encryptedHistory": encrypted.base64EncodedString(),
+                          "timestamp": ISO8601DateFormatter().string(from: Date()),
+                          "deviceID": getDeviceID()]
+            
+            request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+            
+            let (_, response) = try await URLSession.shared.data(for: request)
+            
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
+                UserDefaults.standard.set(Date(), forKey: "lastSyncTime")
+                print("Successfully synced to Pantry")
+            }
+        } catch {
+            print("Failed to sync to Pantry: \(error)")
+        }
+    }
+    
+    func fetchFromPantry() async -> [HistoryEntry] {
+        do {
+            let url = URL(string: "https://getpantry.cloud/apiv1/pantry/\(pantryID)/basket/\(pantryBasket)")!
+            let (data, _) = try await URLSession.shared.data(from: url)
+            
+            let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            guard let encryptedString = json?["encryptedHistory"] as? String,
+                  let encryptedData = Data(base64Encoded: encryptedString) else {
+                return []
+            }
+            
+            let decrypted = try decrypt(encryptedData)
+            var entries = try JSONDecoder().decode([HistoryEntry].self, from: decrypted)
+            
+            // Remove expired entries (older than 30 days)
+            let cutoffDate = Calendar.current.date(byAdding: .day, value: -expirationDays, to: Date())!
+            entries = entries.filter { $0.timestamp > cutoffDate }
+            
+            return entries
+        } catch {
+            print("Failed to fetch from Pantry: \(error)")
+            return []
+        }
+    }
+    
+    private func getDeviceID() -> String {
+        if let id = UserDefaults.standard.string(forKey: "deviceID") {
+            return id
+        }
+        let id = UUID().uuidString
+        UserDefaults.standard.set(id, forKey: "deviceID")
+        return id
+    }
+}
+
+struct HistoryEntry: Codable {
+    let url: String
+    let title: String
+    let timestamp: Date
+    let tabId: Int?
+}

--- a/EncryptedHistorySafari/Info.plist
+++ b/EncryptedHistorySafari/Info.plist
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key>
+    <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.Safari.web-extension</string>
+        <key>NSExtensionPrincipalClass</key>
+        <string>$(PRODUCT_MODULE_NAME).SafariWebExtensionHandler</string>
+    </dict>
+    <key>SFSafariWebExtension</key>
+    <dict>
+        <key>NativeMessaging</key>
+        <dict>
+            <key>AllowedHosts</key>
+            <array>
+                <string>com.encryptedhistory.safari</string>
+            </array>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/EncryptedHistorySafari/README.md
+++ b/EncryptedHistorySafari/README.md
@@ -1,0 +1,51 @@
+# Encrypted History Safari Extension
+
+A Safari extension that stores browsing history encrypted using a secret and syncs it to Pantry cloud storage.
+
+## Features
+
+- Automatically captures browsing history
+- Encrypts history using AES-GCM with a user-defined secret
+- Configurable sync interval (0.5 to 24 hours)
+- Automatic 30-day expiration for old history entries
+- Syncs to Pantry cloud storage at your configured interval or when 100+ entries accumulate
+- Background sync handled by native Swift code
+- Popup UI to view synced history
+- Shows last sync time with automatic updates
+
+## Setup
+
+1. **Get a Pantry ID:**
+   - Go to https://getpantry.cloud
+   - Create a free account to get your Pantry ID
+
+2. **Build the Extension:**
+   - Open the project in Xcode
+   - Build and run the app
+   - Enable the extension in Safari preferences
+
+3. **Configure:**
+   - Set your encryption secret (keep this safe!)
+   - Enter your Pantry ID
+   - Optionally change the basket name (default: "encrypted-history")
+
+## Architecture
+
+- **JavaScript Side:** Captures browsing events and sends to Swift
+- **Swift Side:** Handles encryption, local storage, and background sync
+- **Pantry Storage:** Cloud storage for encrypted history data
+
+## Security
+
+- History is encrypted using AES-GCM before storage
+- Encryption key derived from user secret using SHA256
+- Only encrypted data is sent to Pantry
+- Each device has a unique ID for multi-device support
+
+## Sync Behavior
+
+- Automatic sync at configurable intervals (default 1 hour)
+- Immediate sync when 100+ entries accumulate
+- Manual sync available via popup or settings
+- Resilient to network failures (retries on next sync)
+- History older than 30 days is automatically removed

--- a/EncryptedHistorySafari/SafariWebExtensionHandler.swift
+++ b/EncryptedHistorySafari/SafariWebExtensionHandler.swift
@@ -1,0 +1,93 @@
+import SafariServices
+import os.log
+
+class SafariWebExtensionHandler: NSObject, NSExtensionRequestHandling {
+    
+    private let historyManager: HistoryManager
+    
+    override init() {
+        // Load configuration
+        let secret = UserDefaults.standard.string(forKey: "encryptionSecret") ?? "default-secret-change-me"
+        let pantryID = UserDefaults.standard.string(forKey: "pantryID") ?? ""
+        let pantryBasket = UserDefaults.standard.string(forKey: "pantryBasket") ?? "encrypted-history"
+        
+        self.historyManager = HistoryManager(secret: secret, pantryID: pantryID, pantryBasket: pantryBasket)
+        super.init()
+    }
+    
+    func beginRequest(with context: NSExtensionContext) {
+        let item = context.inputItems[0] as! NSExtensionItem
+        let message = item.userInfo?[SFExtensionMessageKey] as? [String: Any]
+        let response = NSExtensionItem()
+        
+        guard let action = message?["action"] as? String else {
+            response.userInfo = [SFExtensionMessageKey: ["error": "No action specified"]]
+            context.completeRequest(returningItems: [response], completionHandler: nil)
+            return
+        }
+        
+        switch action {
+        case "addHistory":
+            handleAddHistory(message: message, response: response, context: context)
+            
+        case "getHistory":
+            handleGetHistory(message: message, response: response, context: context)
+            
+        case "sync":
+            handleSync(response: response, context: context)
+            
+        default:
+            response.userInfo = [SFExtensionMessageKey: ["error": "Unknown action"]]
+            context.completeRequest(returningItems: [response], completionHandler: nil)
+        }
+    }
+    
+    private func handleAddHistory(message: [String: Any]?, response: NSExtensionItem, context: NSExtensionContext) {
+        guard let data = message?["data"] as? [String: Any],
+              let url = data["url"] as? String,
+              let title = data["title"] as? String,
+              let timestamp = data["timestamp"] as? Double else {
+            response.userInfo = [SFExtensionMessageKey: ["error": "Invalid history data"]]
+            context.completeRequest(returningItems: [response], completionHandler: nil)
+            return
+        }
+        
+        let entry = HistoryEntry(
+            url: url,
+            title: title,
+            timestamp: Date(timeIntervalSince1970: timestamp / 1000),
+            tabId: data["tabId"] as? Int
+        )
+        
+        Task {
+            await historyManager.addHistoryEntry(entry)
+            response.userInfo = [SFExtensionMessageKey: ["success": true]]
+            context.completeRequest(returningItems: [response], completionHandler: nil)
+        }
+    }
+    
+    private func handleGetHistory(message: [String: Any]?, response: NSExtensionItem, context: NSExtensionContext) {
+        Task {
+            let entries = await historyManager.fetchFromPantry()
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .millisecondsSince1970
+            
+            if let data = try? encoder.encode(entries),
+               let json = try? JSONSerialization.jsonObject(with: data) {
+                response.userInfo = [SFExtensionMessageKey: ["history": json]]
+            } else {
+                response.userInfo = [SFExtensionMessageKey: ["history": []]]
+            }
+            
+            context.completeRequest(returningItems: [response], completionHandler: nil)
+        }
+    }
+    
+    private func handleSync(response: NSExtensionItem, context: NSExtensionContext) {
+        Task {
+            await historyManager.syncToPantry()
+            response.userInfo = [SFExtensionMessageKey: ["success": true]]
+            context.completeRequest(returningItems: [response], completionHandler: nil)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Implements a Safari extension that captures browsing history and stores it encrypted in Pantry
- JavaScript extension sends history events to Swift native code
- Swift handles AES-GCM encryption and background sync

## Features
- Configurable sync intervals (0.5-24 hours)
- Automatic 30-day expiration for old history entries  
- Force sync button with last sync time display
- Popup UI for viewing synced history
- Resilient to network failures with automatic retries

## Test plan
- [ ] Build and enable the Safari extension
- [ ] Configure Pantry ID and encryption secret in settings
- [ ] Browse some websites and verify history is captured
- [ ] Check that sync occurs at configured intervals
- [ ] Verify force sync button works
- [ ] Confirm popup shows encrypted history
- [ ] Test that entries older than 30 days are removed

🤖 Generated with [Claude Code](https://claude.ai/code)